### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Instantly create musical instruments out of any device or screen.
 ### What’s is cost?
  Free. BSD license.
 
-###What happen to Beatnik?
+### What happen to Beatnik?
  Beatnik ended business December 2009. Decided to release the miniBAE source as a BSD license rather than let it disappear.
 
 ### What’s with all this Javascript code?


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
